### PR TITLE
prophet 1.3.0 - rebuild py314

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,5 +1,0 @@
-# Newer clang has issues with compiled sections of the code
-c_compiler_version:    # [osx]
-  - 17                 # [osx]
-cxx_compiler_version:  # [osx]
-  - 17                 # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,6 +57,7 @@ test:
     - pytest
     - notebook
     - plotly
+    - tbb
 
 about:
   home: https://facebook.github.io/prophet

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 7ec252e898199a1965ca10db3ca625a4ec75e4e6f738d2b4108fe603666a9ef0
 
 build:
-  number: 0
+  number: 1
   # https://blog.quantinsti.com/installing-prophet-library-windows/
   skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
@@ -38,6 +38,7 @@ requirements:
     - setuptools >=64
     - wheel
     - cmdstanpy >=1.0.4
+    - cmdstan >=2.34
     - tbb-devel
   run:
     - python
@@ -46,6 +47,7 @@ requirements:
     - matplotlib-base >=2.0.0
     - pandas >=1.0.4
     - holidays >=0.25.0,<1
+    - cmdstan >=2.34
     - tqdm >=4.36.1
     - importlib_resources
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,7 +57,6 @@ test:
     - pytest
     - notebook
     - plotly
-    - tbb
 
 about:
   home: https://facebook.github.io/prophet

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,5 +1,5 @@
 import os
-import pkgutil
+import importlib.util
 import platform
 import sys
 import subprocess
@@ -26,8 +26,18 @@ def go():
     m = Prophet()
     print(f'Using backend: {m.stan_backend.get_type()}')
 
-    loader = pkgutil.get_loader("prophet.tests")
-    tests_dir = os.path.dirname(loader.path)
+    spec = importlib.util.find_spec("prophet.tests")
+    if spec is None:
+        print("Error: could not find module spec for prophet.tests")
+        sys.exit(1)
+    if spec.submodule_search_locations:
+        tests_dir = os.fspath(next(iter(spec.submodule_search_locations)))
+    elif spec.origin:
+        tests_dir = os.path.dirname(os.fspath(spec.origin))
+    else:
+        print("Error: could not determine tests directory for prophet.tests")
+        sys.exit(1)
+
     pytest_args = [tests_dir, "-vv"]
     
     # Workaround for pytest fixture discovery on Windows Python 3.10
@@ -43,5 +53,5 @@ def go():
 
 
 if __name__ == "__main__":
-    subprocess.run(["pip", "check"])
+    subprocess.run([sys.executable, "-m", "pip", "check"], check=False)
     go()


### PR DESCRIPTION
prophet 1.3.0 - rebuild py314

**Destination channel:** Defaults

### Links

- [PKG-12181]
- dev_url:        https://github.com/facebook/prophet/tree/v1.3.0
- conda_forge:    https://github.com/conda-forge/prophet-feedstock
- pypi:           https://pypi.org/project/prophet/1.3.0
- pypi inspector: https://inspector.pypi.io/project/prophet/1.3.0

### Explanation of changes:

- rebuild py314
- unvendor cmdstan
- fix test


[PKG-12181]: https://anaconda.atlassian.net/browse/PKG-12181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ